### PR TITLE
spidev: support poll to wait interrupt from SPI controller

### DIFF
--- a/drivers/spi/spidev.c
+++ b/drivers/spi/spidev.c
@@ -26,6 +26,10 @@
 
 #include <linux/uaccess.h>
 
+#include <linux/irq.h>
+#include <linux/interrupt.h>
+#include <linux/poll.h>
+#include <linux/irqdomain.h>
 
 /*
  * This supports access to SPI devices using normal userspace I/O calls.
@@ -79,6 +83,10 @@ struct spidev_data {
 	u8			*tx_buffer;
 	u8			*rx_buffer;
 	u32			speed_hz;
+	int			irq;
+	bool			notified;
+	struct wait_queue_head	waitq;
+	spinlock_t		irq_lock;
 };
 
 static LIST_HEAD(device_list);
@@ -89,6 +97,43 @@ module_param(bufsiz, uint, S_IRUGO);
 MODULE_PARM_DESC(bufsiz, "data bytes in biggest supported SPI message");
 
 /*-------------------------------------------------------------------------*/
+
+static irqreturn_t handshake_irq(int __attribute__((unused)) irq, void *id)
+{
+	struct spidev_data *spidev = id;
+	unsigned long flags;
+
+	spin_lock_irqsave(&spidev->irq_lock, flags);
+	spidev->notified = true;
+	spin_unlock_irqrestore(&spidev->irq_lock, flags);
+	wake_up_interruptible(&spidev->waitq);
+
+	return IRQ_HANDLED;
+}
+
+static int spidev_irq_get(struct spi_device *spi)
+{
+	struct irq_fwspec fwspec;
+	struct irq_domain *domain;
+	struct spi_controller *ctlr = spi->controller;
+	int irq = -EINVAL;
+
+	fwspec.fwnode = dev_fwnode(ctlr->dev.parent);
+	fwspec.param[0] = spi_get_chipselect(spi, 0);
+	fwspec.param[1] = IRQ_TYPE_EDGE_RISING;
+	fwspec.param_count = 2;
+
+	domain = irq_find_matching_fwnode(fwspec.fwnode, DOMAIN_BUS_ANY);
+	if (!domain)
+		return -EINVAL;
+	dev_info(&spi->dev, "found domain: %s\n", domain->name);
+
+	irq = irq_create_fwspec_mapping(&fwspec);
+	if (irq <= 0)
+		return -EINVAL;
+
+	return irq;
+}
 
 static ssize_t
 spidev_sync_unlocked(struct spi_device *spi, struct spi_message *message)
@@ -673,6 +718,22 @@ static int spidev_release(struct inode *inode, struct file *filp)
 	return 0;
 }
 
+static unsigned int spidev_poll(struct file *filp, struct poll_table_struct *wait)
+{
+	struct spidev_data *spidev;
+	__poll_t mask = 0;
+
+	spidev = filp->private_data;
+	poll_wait(filp, &spidev->waitq, wait);
+	if (spidev->notified) {
+		mask |= ( POLLIN | POLLRDNORM );
+		spin_lock_irq(&spidev->irq_lock);
+		spidev->notified = false;
+		spin_unlock_irq(&spidev->irq_lock);
+	}
+	return mask;
+}
+
 static const struct file_operations spidev_fops = {
 	.owner =	THIS_MODULE,
 	/* REVISIT switch to aio primitives, so that userspace
@@ -684,6 +745,7 @@ static const struct file_operations spidev_fops = {
 	.unlocked_ioctl = spidev_ioctl,
 	.compat_ioctl = spidev_compat_ioctl,
 	.open =		spidev_open,
+	.poll =		spidev_poll,
 	.release =	spidev_release,
 };
 
@@ -772,7 +834,7 @@ static int spidev_probe(struct spi_device *spi)
 {
 	int (*match)(struct device *dev);
 	struct spidev_data	*spidev;
-	int			status;
+	int			status, irq;
 	unsigned long		minor;
 
 	match = device_get_match_data(&spi->dev);
@@ -791,6 +853,7 @@ static int spidev_probe(struct spi_device *spi)
 	spidev->spi = spi;
 	mutex_init(&spidev->spi_lock);
 	mutex_init(&spidev->buf_lock);
+	spin_lock_init(&spidev->irq_lock);
 
 	INIT_LIST_HEAD(&spidev->device_entry);
 
@@ -818,6 +881,24 @@ static int spidev_probe(struct spi_device *spi)
 	mutex_unlock(&device_list_lock);
 
 	spidev->speed_hz = spi->max_speed_hz;
+
+	init_waitqueue_head(&spidev->waitq);
+	//ACPI_GENERIC_GSI is NOT supported on x86 !?
+	//irq = fwnode_irq_get(dev_fwnode(&spi->dev), 0);
+	irq = spidev_irq_get(spi);
+	if (irq < 0) {
+		dev_info(&spi->dev, "fail to get device irq %d\n", irq);
+	} else {
+		dev_dbg(&spi->dev, "got mapped irq %d\n", irq);
+		status = request_irq(irq, handshake_irq,
+				IRQF_TRIGGER_RISING, dev_name(&spi->dev),
+				spidev);
+		if (status) {
+			dev_dbg(&spi->dev, "unable to request irq %d\n", irq);
+			status = 0;
+		} else
+			spidev->irq = irq;
+	}
 
 	if (status == 0)
 		spi_set_drvdata(spi, spidev);


### PR DESCRIPTION
Add epoll support for SPI devices transfers based on the per SPI device interrupt mechanism provided by the Virtio SPI controller.

Tracked-On: OAM-131278